### PR TITLE
port field standardization

### DIFF
--- a/Portfolios/Code/01_PortfolioFunction.R
+++ b/Portfolios/Code/01_PortfolioFunction.R
@@ -337,13 +337,8 @@ signalname_to_ports = function(
     ) %>%
     select(port,date,ret,signallag,Nlong,Nshort)        
   
-  
-  # convert port to string and pad left if deciles for ease
-  if (max(nchar(as.character(port$port %>% unique()))) == 1){
-    port = port %>% mutate(port = sprintf('%01d',port))
-  } else {
-    port = port %>% mutate(port = sprintf('%02d',port))
-  }
+  # convert port to 2-character string for ease of use
+  port = port %>% mutate(port = sprintf('%02d',port))
   
   # bind long with longshort
   port = rbind(port,longshort)

--- a/Portfolios/Code/20_PredictorPorts.R
+++ b/Portfolios/Code/20_PredictorPorts.R
@@ -1,7 +1,7 @@
 # For baseline portfolio tests
 # Andrew Chen 2020 01
 
-# ==== ENVIRONMENT AND DATA ====
+# ENVIRONMENT AND DATA ====
 crspinfo = read.fst(
   paste0(pathProject,'Portfolios/Data/Intermediate/crspminfo.fst')
 ) %>% # me, screens, 
@@ -11,10 +11,7 @@ crspret = read.fst(
 ) %>% # returns
   setDT()
 
-
-######################################################################
-### SELECT SIGNALS AND CHECK FOR CSVS
-######################################################################
+# SELECT SIGNALS AND CHECK FOR CSVS ====
 
 strategylist0 <- alldocumentation %>% filter(Cat.Signal == "Predictor")
 strategylist0 <- ifquickrun()
@@ -36,10 +33,7 @@ if (dim(missing)[1]>0){
   if (temp=='quit'){print('erroring out'); stop()}
 }
 
-
-#####################################################################
-### BASE PORTS
-#####################################################################
+# BASE PORTS ====
 port <- loop_over_strategies(
   strategylist0
 )
@@ -64,7 +58,7 @@ writestandard(
   "PredictorLSretWide.csv"
 )
 
-# SUMMARY STATS BY SIGNAL -------------------------------------------------
+# SUMMARY STATS BY SIGNAL ====
 
 # reread in case you want to edit the summary later
 port = read.csv(paste0(pathDataPortfolios, "PredictorPortsFull.csv"))
@@ -98,7 +92,7 @@ write_xlsx(
 )
 
 
-# FEEDBACK ON ERRORS -------------------------------------------------
+# FEEDBACK ON ERRORS ====
 
 print("The following ports are computed succesfully")
 print(


### PR DESCRIPTION
This commit always uses 2 characters (port 1 is always port "01" ).  The April 2021 data release seems to always use 2 characters.  https://drive.google.com/drive/folders/1I6nMmo8k_zGCcp9tUvmMedKTAkb9734R.  

I think the current portfolio code was patched to use 1 or 2 characters depending on the total number of ports sometime after the April 2021 release was posted.  But there isn't a great reason to make it so complicated.